### PR TITLE
Updating wls_admin service

### DIFF
--- a/src/main/scripts/setupAdminDomain.sh
+++ b/src/main/scripts/setupAdminDomain.sh
@@ -153,6 +153,8 @@ echo "Creating weblogic admin server service"
 cat <<EOF >/etc/systemd/system/wls_admin.service
 [Unit]
 Description=WebLogic Adminserver service
+After=network-online.target
+Wants=network-online.target
  
 [Service]
 Type=simple
@@ -163,6 +165,8 @@ User=oracle
 Group=oracle
 KillMode=process
 LimitNOFILE=65535
+Restart=always
+RestartSec=3
  
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
wls_admin service is updated with following
- Added network service as prerequisite
- Added restart if service is failed

Fix for the [Issue #160 : CI/CD test scenarios failing intermittently due to nodemanager service failure](https://github.com/wls-eng/arm-oraclelinux-wls/issues/160)

Refer CI/CD trial run , https://github.com/sanjaymantoor/arm-oraclelinux-wls-admin/actions/runs/232193341