### PR TITLE
Fix `set-env` command; it is deprecated and will be disabled soon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Create a new branch with development pids in nestedtemplates
       run: |
         current=`pwd`
-        echo "##[set-env name=current;]${current}"
+        echo "current=${current}" >> $GITHUB_ENV
         cd ${{ env.offerName }}-dev/src/main/arm/nestedtemplates
         git config --global core.longpaths true
         git config --global user.email $userEmail
@@ -94,11 +94,13 @@ jobs:
              
     - name: Get version information from pom.xml
       id: version
-      run: echo "##[set-env name=version;]$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${{ env.offerName }}/pom.xml)"
+      run: |
+        version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${{ env.offerName }}/pom.xml)
+        echo "version=${version}" >> $GITHUB_ENV
     - name: Print version
       run: echo $version
     - name: Generate artifact name
-      run: echo "##[set-env name=artifactName;]${{ env.offerName }}-$version-arm-assembly"
+      run: echo "artifactName=${{ env.offerName }}-$version-arm-assembly" >> $GITHUB_ENV
     - name: Print artifact name
       run: echo $artifactName
     - name: Output artifact name
@@ -171,12 +173,14 @@ jobs:
         path: ${{ env.offerName }}
     - name: Get version information from ${{ env.offerName }}/pom.xml
       id: version
-      run: echo "##[set-env name=version;]$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${{ env.offerName }}/pom.xml)"
+      run: |
+        version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${{ env.offerName }}/pom.xml)
+        echo "version=${version}" >> $GITHUB_ENV
     - name: Output artifact name for Download action
       id: artifact_file
       run: |
         artifactName=${{ env.offerName }}-$version-arm-assembly
-        echo "##[set-env name=artifactName;]${artifactName}"
+        echo "artifactName=${artifactName}" >> $GITHUB_ENV
         echo "##[set-output name=artifactName;]${artifactName}"
     - name: Download artifact for deployment
       uses: actions/download-artifact@v1
@@ -192,16 +196,17 @@ jobs:
       run: |
         imageUrn="${{ matrix.images }}"
         sku=${imageUrn%%;*}
-        echo "##[set-env name=sku;]${sku}"
+        echo "sku=${sku}" >> $GITHUB_ENV
+        echo ${resourceGroupPrefix}
+        resourceGroup=$(echo "${resourceGroupPrefix}-${sku}" | sed "s/_//g")
+        echo "resourceGroup=${resourceGroup}" >> $GITHUB_ENV
     - name: Create Resource Group
       id: create-resource-group
       uses: azure/CLI@v1
       with:
         azcliversion: ${{ env.azCliVersion }}
         inlineScript: |
-          resourceGroup=${{ env.resourceGroupPrefix }}-${sku}
           echo "create resource group" $resourceGroup
-          echo "##[set-env name=resourceGroup;]${resourceGroup}"
           az group create --verbose --name $resourceGroup --location ${location}
           
     - name: Prepare deployed parameters and test script
@@ -263,7 +268,7 @@ jobs:
       id: get-ip-address
       run: |
         myIP=$(dig @ns1.google.com TXT o-o.myaddr.l.google.com +short)
-        echo "##[set-env name=myIP;]${myIP}"          
+        echo "myIP=${myIP}" >> $GITHUB_ENV
 
     - name: Add ip address to security rule to access the wls machine
       id: add-ip-to-security-rule
@@ -313,8 +318,10 @@ jobs:
             --resource-group $resourceGroup \
             --name $adminVMName -d \
             --query publicIps -o tsv)
-          echo "VM Public IP ${publicIp}"
-          echo "##[set-env name=wlsPublicIP;]${publicIP}"  
+          echo "##[set-output name=publicIP;]${publicIP}"
+    - name: Create environment variable for AdminServer IP
+      id: env-admin-ip
+      run: echo "wlsPublicIP=${{steps.query-wls-admin-ip.outputs.publicIP}}" >> $GITHUB_ENV
 
     - name: Verify WebLogic Server Installation
       id: verify-wls


### PR DESCRIPTION
Reference: [GitHub Actions: Deprecating set-env and add-path commands](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)