### PR TITLE
Bugfix: update the deployment dependency for NSG

### DIFF
--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -472,29 +472,6 @@
          }
       },
       {
-         "type": "Microsoft.Resources/deployments",
-         "apiVersion": "${azure.apiVersion}",
-         "name": "networkSecurityLinkedTemplate",
-         "properties": {
-            "mode": "Incremental",
-            "templateLink": {
-               "uri": "[uri(parameters('_artifactsLocation'), concat('nestedtemplates/', variables('name_nsgLinkedTemplateName')))]",
-               "contentVersion": "1.0.0.0"
-            },
-            "parameters": {
-               "denyPublicTrafficForAdminServer": {
-                  "value": "[parameters('denyPublicTrafficForAdminServer')]"
-               },
-               "networkSecurityGroupName": {
-                  "value": "[concat(parameters('dnsLabelPrefix'), '-nsg')]"
-               }
-            }
-         },
-         "dependsOn": [
-            "[resourceId('Microsoft.Resources/deployments', 'adminLinkedTemplate')]"
-         ]
-      },
-      {
          "name": "adminCustomSSLLinkedTemplate",
          "type": "Microsoft.Resources/deployments",
          "apiVersion": "${azure.apiVersion}",
@@ -625,6 +602,30 @@
                }
             }
          }
+      },
+      {
+         "type": "Microsoft.Resources/deployments",
+         "apiVersion": "${azure.apiVersion}",
+         "name": "networkSecurityLinkedTemplate",
+         "properties": {
+            "mode": "Incremental",
+            "templateLink": {
+               "uri": "[uri(parameters('_artifactsLocation'), concat('nestedtemplates/', variables('name_nsgLinkedTemplateName')))]",
+               "contentVersion": "1.0.0.0"
+            },
+            "parameters": {
+               "denyPublicTrafficForAdminServer": {
+                  "value": "[parameters('denyPublicTrafficForAdminServer')]"
+               },
+               "networkSecurityGroupName": {
+                  "value": "[concat(parameters('dnsLabelPrefix'), '-nsg')]"
+               }
+            }
+         },
+         "dependsOn": [
+            "[resourceId('Microsoft.Resources/deployments', 'adminLinkedTemplate')]",
+            "[resourceId('Microsoft.Resources/deployments', 'adminCustomSSLLinkedTemplate')]"
+         ]
       },
       {
          "name": "dbLinkedTemplate",


### PR DESCRIPTION
Add missed dependency to ensure the NSG deployment happens after either the password or the SSL based server deployment.

@edburns Hi Ed, I found a bug of my last PR and here is the fix. It's been verified through Azure portal, please review it.