### PR TITLE
Update texts and default values

### DIFF
--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -182,7 +182,7 @@
                         "type": "Microsoft.Common.TextBox",
                         "label": "WebLogic Domain Name",
                         "toolTip": "The name of the WebLogic Domain to create.",
-                        "defaultValue": "clusterDomain",
+                        "defaultValue": "adminDomain",
                         "constraints": {
                             "required": true,
                             "regex": "^[a-z0-9A-Z]{3,20}$",
@@ -796,12 +796,9 @@
                                 "name": "deplymentScriptInfo",
                                 "type": "Microsoft.Common.TextBlock",
                                 "options": {
-                                    "text": "Bring Azure DNS Zone option will add records to your DNS Zone to cause Oracle WebLogic Server Administration Console accessible via DNS alias. We need a user-assigned managed identity to update your resource group that has Azure DNS Zone deployed. ",
-                                    "link": {
-                                        "label": "Learn more",
-                                        "uri": "https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deployment-script-template"
-                                    }
-                                }
+                                    "text": "If you choose to use an existing Azure DNS Zone, you must select a user-assigned managed identity to enable the necessary configuration."
+                                },
+                                "visible": "[steps('section_dnsConfiguration').customDNSSettings.bringDNSZone]"
                             },
                             {
                                 "name": "dnszoneName",


### PR DESCRIPTION
On Basic blade optional configuration, update the WebLogic Domain Name to be 'adminDomain'
On DNS Configuration blade, update the text's visibility, words, and remove 'learn more' link
