### PR TITLE
improve ui

### DIFF
--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -401,8 +401,8 @@
                             {
                                 "name": "uploadedCustomIdentityKeyStoreData",
                                 "type": "Microsoft.Common.FileUpload",
-                                "label": "Custom Identity KeyStore Data file(.jks,.p12)",
-                                "toolTip": "Custom Identity KeyStore for TLS/SSL configuration",
+                                "label": "Identity KeyStore Data file(.jks,.p12)",
+                                "toolTip": "Identity KeyStore for TLS/SSL configuration",
                                 "constraints": {
                                     "required": true,
                                     "accept": ".jks,.p12"
@@ -421,11 +421,11 @@
                                     "password": "Password",
                                     "confirmPassword": "Confirm password"
                                 },
-                                "toolTip": " The passphrase for the Custom Identity KeyStore",
+                                "toolTip": " The passphrase for the Identity KeyStore",
                                 "constraints": {
                                     "required": true,
-                                    "regex": "^((?=.*[0-9])(?=.*[a-z])|(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])|(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&*])|(?=.*[0-9])(?=.*[A-Z])(?=.*[!@#$%^&*])|(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*])).{6,128}$",
-                                    "validationMessage": "The password must contain at least 6 characters, with at least 1 uppercase letter, 1 lowercase letter and 1 number."
+                                    "regex": "^.{6,}$",
+                                    "validationMessage": "Keypass must be at least 6 characters long."
                                 },
                                 "options": {
                                     "hideConfirmation": false
@@ -454,10 +454,41 @@
                                 }
                             },
                             {
+                                "name": "uploadedPrivateKeyAlias",
+                                "type": "Microsoft.Common.TextBox",
+                                "visible": "true",
+                                "label": "The alias of the server's private key witin the Identity KeyStore",
+                                "defaultValue": "",
+                                "toolTip": "Use only letters and numbers",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^[a-z0-9A-Z]{1,30}$",
+                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
+                                }
+                            },
+                            {
+                                "name": "uploadedPrivateKeyPassPhrase",
+                                "type": "Microsoft.Common.PasswordBox",
+                                "visible": "true",
+                                "label": {
+                                    "password": "The passphrase for server's the private key within the Identity KeyStore",
+                                    "confirmPassword": "Confirm passphrase"
+                                },
+                                "toolTip": "Use only letters and numbers",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^.{6,}$",
+                                    "validationMessage": "Keypass must be at least 6 characters long."
+                                },
+                                "options": {
+                                    "hideConfirmation": false
+                                }
+                            },
+                            {
                                 "name": "uploadedCustomTrustKeyStoreData",
                                 "type": "Microsoft.Common.FileUpload",
-                                "label": "Custom Trust KeyStore Data file(.jks,.p12)",
-                                "toolTip": "Custom Trust KeyStore for TLS/SSL configuration.",
+                                "label": "Trust KeyStore Data file(.jks,.p12)",
+                                "toolTip": "Trust KeyStore for TLS/SSL configuration.",
                                 "constraints": {
                                     "required": true,
                                     "accept": ".jks,.p12"
@@ -476,11 +507,11 @@
                                     "password": "Password",
                                     "confirmPassword": "Confirm password"
                                 },
-                                "toolTip": " The passphrase for the Custom Trust KeyStore",
+                                "toolTip": " The passphrase for the Trust KeyStore",
                                 "constraints": {
                                     "required": true,
-                                    "regex": "^((?=.*[0-9])(?=.*[a-z])|(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])|(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&*])|(?=.*[0-9])(?=.*[A-Z])(?=.*[!@#$%^&*])|(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*])).{6,128}$",
-                                    "validationMessage": "The password must contain at least 6 characters, with at least 1 uppercase letter, 1 lowercase letter and 1 number."
+                                    "regex": "^.{6,}$",
+                                    "validationMessage": "Keypass must be at least 6 characters long."
                                 },
                                 "options": {
                                     "hideConfirmation": false
@@ -491,7 +522,7 @@
                                 "name": "uploadedCustomTrustKeyStoreType",
                                 "type": "Microsoft.Common.DropDown",
                                 "visible": "true",
-                                "label": "The Custom Trust KeyStore type (JKS,PKCS12)",
+                                "label": "The Trust KeyStore type (JKS,PKCS12)",
                                 "defaultValue": "JKS",
                                 "toolTip": "Use only letters and numbers",
                                 "constraints": {
@@ -506,37 +537,6 @@
                                         }
                                     ],
                                     "required": true
-                                }
-                            },
-                            {
-                                "name": "uploadedPrivateKeyAlias",
-                                "type": "Microsoft.Common.TextBox",
-                                "visible": "true",
-                                "label": "The private Key Alias",
-                                "defaultValue": "",
-                                "toolTip": "Use only letters and numbers",
-                                "constraints": {
-                                    "required": true,
-                                    "regex": "^[a-z0-9A-Z]{1,30}$",
-                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
-                                }
-                            },
-                            {
-                                "name": "uploadedPrivateKeyPassPhrase",
-                                "type": "Microsoft.Common.PasswordBox",
-                                "visible": "true",
-                                "label": {
-                                    "password": "The passphrase for the Private Key",
-                                    "confirmPassword": "Confirm passphrase"
-                                },
-                                "toolTip": "Use only letters and numbers",
-                                "constraints": {
-                                    "required": true,
-                                    "regex": "^((?=.*[0-9])(?=.*[a-z])|(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])|(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&*])|(?=.*[0-9])(?=.*[A-Z])(?=.*[!@#$%^&*])|(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*])).{6,128}$",
-                                    "validationMessage": "The passphrase must contain at least 6 characters, with at least 1 uppercase letter, 1 lowercase letter and 1 number."
-                                },
-                                "options": {
-                                    "hideConfirmation": false
                                 }
                             }
                         ]
@@ -553,7 +553,7 @@
                                 "visible": "true",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "It's not allowed to use the same keystore for identity and trust. Click the link for how to obtain and store certificates for development and production environments.",
+                                    "text": "You must provide different files for identity and trust KeyStores. Select here for more details.",
                                     "uri": "https://aka.ms/arm-oraclelinux-wls-ssl-configuration"
                                 }
                             },
@@ -562,7 +562,7 @@
                                 "type": "Microsoft.Common.TextBlock",
                                 "visible": "true",
                                 "options": {
-                                    "text": "Enabling a HTTPS (Secure) port for the Administration Console requires you to obtain a valid TLS/SSL certificate. The template will look for the certificate and other configuration items in the Azure KeyVault specified here.",
+                                    "text": "Enabling a HTTPS (Secure) port for the Administration Console requires you to obtain a valid TLS/SSL certificate. The template will look for the certificate and other configuration items in the Azure Key Vault specified here.",
                                     "link": {
                                         "label": "Learn more",
                                         "uri": "https://aka.ms/arm-oraclelinux-wls-cluster-app-gateway-key-vault"
@@ -573,7 +573,7 @@
                                 "name": "keyVaultResourceGroup",
                                 "type": "Microsoft.Common.TextBox",
                                 "visible": "true",
-                                "label": "Resource group name in current subscription containing the KeyVault",
+                                "label": "Resource group name in current subscription containing the Key Vault",
                                 "defaultValue": "",
                                 "toolTip": "Use only letters and numbers",
                                 "constraints": {
@@ -586,7 +586,7 @@
                                 "name": "keyVaultName",
                                 "type": "Microsoft.Common.TextBox",
                                 "visible": "true",
-                                "label": "Name of the Azure KeyVault containing secrets for the TLS/SSL certificate",
+                                "label": "Name of the Azure Key Vault containing secrets for the TLS/SSL certificate",
                                 "defaultValue": "",
                                 "toolTip": "Use only letters and numbers",
                                 "constraints": {
@@ -599,7 +599,7 @@
                                 "name": "keyVaultCustomIdentityKeyStoreDataSecretName",
                                 "type": "Microsoft.Common.TextBox",
                                 "visible": "true",
-                                "label": "The name of the secret in the specified KeyVault whose value is the Identity KeyStore Data",
+                                "label": "The name of the secret in the specified Key Vault whose value is the Identity KeyStore Data",
                                 "defaultValue": "",
                                 "toolTip": "Use only letters and numbers",
                                 "constraints": {
@@ -612,7 +612,7 @@
                                 "name": "keyVaultCustomIdentityKeyStorePassPhraseSecretName",
                                 "type": "Microsoft.Common.TextBox",
                                 "visible": "true",
-                                "label": "The name of the secret in the specified KeyVault whose value is the passphrase for the Identity KeyStore",
+                                "label": "The name of the secret in the specified Key Vault whose value is the passphrase for the Identity KeyStore",
                                 "defaultValue": "",
                                 "toolTip": "Use only letters and numbers",
                                 "constraints": {
@@ -643,10 +643,36 @@
                                 }
                             },
                             {
+                                "name": "keyVaultPrivateKeyAliasSecretName",
+                                "type": "Microsoft.Common.TextBox",
+                                "visible": "true",
+                                "label": "The name of the secret in the specified Key Vault whose value is the Private Key Alias",
+                                "defaultValue": "",
+                                "toolTip": "Use only letters and numbers",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^[a-z0-9A-Z]{1,30}$",
+                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
+                                }
+                            },
+                            {
+                                "name": "keyVaultPrivateKeyPassPhraseSecretName",
+                                "type": "Microsoft.Common.TextBox",
+                                "visible": "true",
+                                "label": "The name of the secret in the specified Key Vault whose value is the passphrase for the Private Key",
+                                "defaultValue": "",
+                                "toolTip": "Use only letters and numbers",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^[a-z0-9A-Z]{1,30}$",
+                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
+                                }
+                            },
+                            {
                                 "name": "keyVaultCustomTrustKeyStoreDataSecretName",
                                 "type": "Microsoft.Common.TextBox",
                                 "visible": "true",
-                                "label": "The name of the secret in the specified KeyVault whose value is the Trust KeyStore Data",
+                                "label": "The name of the secret in the specified Key Vault whose value is the Trust KeyStore Data",
                                 "defaultValue": "",
                                 "toolTip": "Use only letters and numbers",
                                 "constraints": {
@@ -659,7 +685,7 @@
                                 "name": "keyVaultCustomTrustKeyStorePassPhraseSecretName",
                                 "type": "Microsoft.Common.TextBox",
                                 "visible": "true",
-                                "label": "The name of the secret in the specified KeyVault whose value is the passphrase for the Trust KeyStore",
+                                "label": "The name of the secret in the specified Key Vault whose value is the passphrase for the Trust KeyStore",
                                 "defaultValue": "",
                                 "toolTip": "Use only letters and numbers",
                                 "constraints": {
@@ -687,32 +713,6 @@
                                         }
                                     ],
                                     "required": true
-                                }
-                            },
-                            {
-                                "name": "keyVaultPrivateKeyAliasSecretName",
-                                "type": "Microsoft.Common.TextBox",
-                                "visible": "true",
-                                "label": "The name of the secret in the specified KeyVault whose value is the Private Key Alias",
-                                "defaultValue": "",
-                                "toolTip": "Use only letters and numbers",
-                                "constraints": {
-                                    "required": true,
-                                    "regex": "^[a-z0-9A-Z]{1,30}$",
-                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
-                                }
-                            },
-                            {
-                                "name": "keyVaultPrivateKeyPassPhraseSecretName",
-                                "type": "Microsoft.Common.TextBox",
-                                "visible": "true",
-                                "label": "The name of the secret in the specified KeyVault whose value is the passphrase for the Private Key",
-                                "defaultValue": "",
-                                "toolTip": "Use only letters and numbers",
-                                "constraints": {
-                                    "required": true,
-                                    "regex": "^[a-z0-9A-Z]{1,30}$",
-                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
                                 }
                             }
                         ]

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -436,7 +436,7 @@
                                 "name": "uploadedCustomIdentityKeyStoreType",
                                 "type": "Microsoft.Common.DropDown",
                                 "visible": "true",
-                                "label": "The Custom Identity KeyStore type (JKS,PKCS12)",
+                                "label": "The Identity KeyStore type (JKS,PKCS12)",
                                 "defaultValue": "JKS",
                                 "toolTip": "Use only letters and numbers",
                                 "constraints": {


### PR DESCRIPTION
modified: arm-oraclelinux-wls-admin/src/main/arm/createUiDefinition.json

Remove the word "Custom" from all places it appears in relation to KeyStore instances.

Make the validation regex for KeyStore passphrase instances as relaxed
as Java keytool. Specifically, the only requirement is "must be at
least 6 characters long. This happens in three places for the
cluster offer. Make sure to get all the places where this happens in
the other offers.

Move the UI pertaining to the alias and passphrase for the private key
within the Identity KeyStore so that it immediately follows the UI for
the Identity KeyStore.

Update the text pertaining to the alias and passphrase of the private
key within the Identity KeyStore to make it more descriptive.

Make the text of the sslKeyStoreInfo InfoBox instances the same.

