### PR TITLE
On branch gh-299-database-password-validation-relaxation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
     <properties>
-        <test.parameters>-TestParameter '@{&quot;PasswordMinLength&quot;=6}'</test.parameters>
+        <test.parameters>-TestParameter '@{&quot;PasswordMinLength&quot;=5}'</test.parameters>
         <template.pid.properties.url>https://raw.githubusercontent.com/wls-eng/arm-oraclelinux-wls/develop/src/main/resources/pid.properties</template.pid.properties.url>
         <template.microsoft.pid.properties.url>https://raw.githubusercontent.com/wls-eng/arm-oraclelinux-wls/develop/src/main/resources/microsoft-pid.properties</template.microsoft.pid.properties.url>
     </properties>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -992,8 +992,8 @@
                                 "toolTip": "Database Password",
                                 "constraints": {
                                     "required": "[bool(steps('section_database').enableDB)]",
-                                    "regex": "^((?=.*[0-9])(?=.*[a-z])|(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])|(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&*])|(?=.*[0-9])(?=.*[A-Z])(?=.*[!@#$%^&*])|(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*])).{6,128}$",
-                                    "validationMessage": "The password must contain at least 6 characters, with at least 1 uppercase letter, 1 lowercase letter and 1 number."
+                                    "regex": "^((?=.*[0-9])(?=.*[a-zA-Z!@#$%^&*])).{5,128}$",
+                                    "validationMessage": "The password must be between five and 128 characters long and have at least one number."
                                 },
                                 "options": {
                                     "hideConfirmation": false


### PR DESCRIPTION
modified:   pom.xml

- Reduce `PasswordMinLength` to 5.

modified:   src/main/arm/createUiDefinition.json

The validation requirements for the database password field must only be as strict as the least strict of the three supported databases. According to Oracle, that means the validation requirements should be 5 chars min, at least one number.

This issue asks the assignee to update the createUiDefinition.json so that

- The validation regEx represents that requirement.
- The validation message states that requirement.

Signed-off-by: Ed Burns <edburns@microsoft.com>