### PR TITLE
On branch gh-300-keystore-type-fix-tooltip

### DIFF
--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -438,7 +438,7 @@
                                 "visible": "true",
                                 "label": "The Identity KeyStore type (JKS,PKCS12)",
                                 "defaultValue": "JKS",
-                                "toolTip": "Use only letters and numbers",
+                                "toolTip": "One of the supported KeyStore types",
                                 "constraints": {
                                     "allowedValues": [
                                         {
@@ -524,7 +524,7 @@
                                 "visible": "true",
                                 "label": "The Trust KeyStore type (JKS,PKCS12)",
                                 "defaultValue": "JKS",
-                                "toolTip": "Use only letters and numbers",
+                                "toolTip": "One of the supported KeyStore types",
                                 "constraints": {
                                     "allowedValues": [
                                         {
@@ -627,7 +627,7 @@
                                 "visible": "true",
                                 "label": "The Identity KeyStore type (JKS,PKCS12)",
                                 "defaultValue": "JKS",
-                                "toolTip": "Use only letters and numbers",
+                                "toolTip": "One of the supported KeyStore types",
                                 "constraints": {
                                     "allowedValues": [
                                         {
@@ -700,7 +700,7 @@
                                 "visible": "true",
                                 "label": "The Trust KeyStore type (JKS,PKCS12)",
                                 "defaultValue": "JKS",
-                                "toolTip": "Use only letters and numbers",
+                                "toolTip": "One of the supported KeyStore types",
                                 "constraints": {
                                     "allowedValues": [
                                         {


### PR DESCRIPTION
https://github.com/wls-eng/arm-oraclelinux-wls/issues/300

modified:   src/main/arm/createUiDefinition.json

- Replace "Use only letters and numbers" with "One of the supported KeyStore types" in the context of the KeyStore type dropdown.

Signed-off-by: Ed Burns <edburns@microsoft.com>